### PR TITLE
Use Computed with graph function types.

### DIFF
--- a/circonus/consts.go
+++ b/circonus/consts.go
@@ -53,7 +53,6 @@ const (
 	defaultGraphDatapoints = 8
 	defaultGraphLineStyle  = "stepped"
 	defaultGraphStyle      = "line"
-	defaultGraphFunction   = "gauge"
 
 	metricUnit       = ""
 	metricUnitRegexp = `^.*$`


### PR DESCRIPTION
Specifying the default function type where `metric_type="text"` was
"problematic."  Use `Computed` and everyone wins.