### PR TITLE
provider/constants: Change minSeverity to 0

### DIFF
--- a/circonus/provider.go
+++ b/circonus/provider.go
@@ -21,7 +21,7 @@ const (
 	defaultCirconusTimeoutMax            = "300s"
 	defaultCirconusTimeoutMin            = "0s"
 	maxSeverity                          = 5
-	minSeverity                          = 1
+	minSeverity                          = 0
 )
 
 var providerDescription = map[string]string{

--- a/website/docs/r/rule_set.html.markdown
+++ b/website/docs/r/rule_set.html.markdown
@@ -323,7 +323,7 @@ A `then` block can have the following attributes:
 * `notify` - (Optional) A list of contact group IDs to notify when this rule is
   sends off a notification.
 * `severity` - (Optional) The severity level of the notification.  This can be
-  set to any value between `1` and `5`.  Defaults to `1`.
+  set to any value between `0` and `5`.  Defaults to `1`.
 
 ## Import Example
 


### PR DESCRIPTION
When trying to clear the alert from a ruleset, the API Object specifies
that the severity is 0 to clear that alert

This PR changes the min severity to be 0 to allow this to be the case