### PR TITLE
upd: circonus-gometrics v2.2.4 (patch for worksheet required attributes)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -98,15 +98,15 @@
   version = "v3.5.1"
 
 [[projects]]
-  digest = "1:58bb1c5fc3f3f352b7e963e3689c804ed5902b1b47c0651737267365bf9162ac"
+  digest = "1:97b1b04f85350861d8b3c6755dc12d41875c98a91933d4eda5a1c17e82467f7f"
   name = "github.com/circonus-labs/circonus-gometrics"
   packages = [
     "api",
     "api/config",
   ]
   pruneopts = "UT"
-  revision = "45b42878bb7aca6fc64fe0a6641a2aa1a5cb2723"
-  version = "v2.2.3"
+  revision = "03033123293bfe2241d1f7e1a3de8fb508265251"
+  version = "v2.2.4"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"

--- a/vendor/github.com/circonus-labs/circonus-gometrics/api/worksheet.go
+++ b/vendor/github.com/circonus-labs/circonus-gometrics/api/worksheet.go
@@ -30,19 +30,21 @@ type WorksheetSmartQuery struct {
 
 // Worksheet defines a worksheet. See https://login.circonus.com/resources/api/calls/worksheet for more information.
 type Worksheet struct {
-	CID          string                `json:"_cid,omitempty"` // string
-	Description  *string               `json:"description"`    // string or null
-	Favorite     bool                  `json:"favorite"`       // boolean
-	Graphs       []WorksheetGraph      `json:"graphs"`         // [] len >= 0
-	Notes        *string               `json:"notes"`          // string or null
-	SmartQueries []WorksheetSmartQuery `json:"smart_queries"`  // [] len >= 0
-	Tags         []string              `json:"tags"`           // [] len >= 0
-	Title        string                `json:"title"`          // string
+	CID          string                `json:"_cid,omitempty"`          // string
+	Description  *string               `json:"description"`             // string or null
+	Favorite     bool                  `json:"favorite"`                // boolean
+	Graphs       []WorksheetGraph      `json:"graphs"`                  // [] len >= 0
+	Notes        *string               `json:"notes"`                   // string or null
+	SmartQueries []WorksheetSmartQuery `json:"smart_queries,omitempty"` // [] len >= 0
+	Tags         []string              `json:"tags"`                    // [] len >= 0
+	Title        string                `json:"title"`                   // string
 }
 
 // NewWorksheet returns a new Worksheet (with defaults, if applicable)
 func NewWorksheet() *Worksheet {
-	return &Worksheet{}
+	return &Worksheet{
+		Graphs: []WorksheetGraph{}, // graphs is a required attribute and cannot be null
+	}
 }
 
 // FetchWorksheet retrieves worksheet with passed cid.


### PR DESCRIPTION
Update circonus-gometrics to v2.2.4 containing a patch for required Worksheet attributes. `Worksheet.Graphs` is required `Worksheet.SmartQueries` is optional. `api.NewWorksheet` now correctly returns a stub with `Graphs: []api.WorksheetGraphs{}` to prevent the required attribute being submitted as `null` in the JSON.