### PR TITLE
circonus_worksheet: add an empty order to smart_queries.

### DIFF
--- a/circonus/resource_circonus_worksheet.go
+++ b/circonus/resource_circonus_worksheet.go
@@ -274,6 +274,7 @@ func (w *circonusWorksheet) ParseConfig(d *schema.ResourceData) error {
 
 		for _, queryListRaw := range queriesList {
 			var query api.WorksheetSmartQuery
+			query.Order = []string{}
 			queryAttrs := queryListRaw.(map[string]interface{})
 
 			if v, found := queryAttrs[queryNameAttr]; found {


### PR DESCRIPTION
This is a required workaround until circonus-labs/circonus-gometrics/pull/79
is merged.

CC @maier 