### PR TITLE
fix CAQL datapoints in circonus_graph resource

### DIFF
--- a/circonus/resource_circonus_graph.go
+++ b/circonus/resource_circonus_graph.go
@@ -724,6 +724,17 @@ func (g *circonusGraph) ParseConfig(d *schema.ResourceData) error {
 				}
 			}
 
+			if v, found := metricAttrs[graphMetricCAQLAttr]; found {
+				switch u := v.(type) {
+				case string:
+					datapoint.CAQL = &u
+				case *string:
+					datapoint.CAQL = u
+				default:
+					return fmt.Errorf("PROVIDER BUG: unsupported type for %q: %T", graphMetricAttr, v)
+				}
+			}
+
 			if v, found := metricAttrs[graphMetricMetricTypeAttr]; found {
 				s := v.(string)
 				if s != "" {


### PR DESCRIPTION
Circonus graph resource seemed to halfway support the CAQL datapoint type. This fixes graph creation when the graph has CAQL datapoints (actually create them).